### PR TITLE
Enhancement: Add ability to enable for all headings with front matter flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ will be replaced to:
 ## 3. Third
 ```
 
+***OR***
+
+You can set
+
+```yaml
+numbered-headings: true
+```
+
+in the front matter of any page and then all headings in that page will
+be numbered.
+
 That's it!
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ numbered-headings: true
 in the front matter of any page and then all headings in that page will
 be numbered.
 
+If using `numbered-headings: true` in the front matter, you can also set `numbered-headings-min-level` and
+`numbered-headings-max-level` in the front matter to control which levels to include in the numbering. The
+default values are `2` and `6`, respectively.
+
 That's it!
 
 ## Development

--- a/lib/jekyll/_plugins/numbered_headings.rb
+++ b/lib/jekyll/_plugins/numbered_headings.rb
@@ -3,11 +3,13 @@ Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
   levels = Array.new(max_level, 0)
   in_code_block = false
 
+  return unless article.data['numbered-headings'] == true
+
   converted_lines = article.content.split("\n").map do |line|
     in_code_block = !in_code_block if line.match(/^```/)
     next line if in_code_block
 
-    matched = line.match(/^(#+)1\. (.+)/)
+    matched = line.match(/^(#+) (.+)/)
     next line unless matched
 
     heading = matched[1]

--- a/lib/jekyll/_plugins/numbered_headings.rb
+++ b/lib/jekyll/_plugins/numbered_headings.rb
@@ -1,17 +1,21 @@
 NUMBERED_HEADING_REGEX = /^(#+)1\. (.+)/
 HEADING_REGEX = /^(#+) (.+)/
+MIN_LEVEL = 2
+MAX_LEVEL = 6
 
 Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
-  max_level = 6
-  levels = Array.new(max_level, 0)
-  in_code_block = false
-
   # If "numbered-headings: true" in front matter, number regular headings too.
-  if article.data["numbered-headings"] == true
+  global_page_numbered_headings = article.data.fetch("numbered_headings", false)
+  if global_page_numbered_headings
     heading_regex = Regexp.union(HEADING_REGEX, NUMBERED_HEADING_REGEX)
+    min_level = article.data.fetch("numbered-headings-min-level", MIN_LEVEL)
+    max_level = article.data.fetch("numbered-headings-min-level", MAX_LEVEL)
   else
     heading_regex = NUMBERED_HEADING_REGEX
   end
+
+  levels = Array.new(max_level, 0)
+  in_code_block = false
 
   converted_lines = article.content.split("\n").map do |line|
     in_code_block = !in_code_block if line.match(/^```/)
@@ -23,7 +27,7 @@ Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
     heading = matched[1]
     level = heading.length
     text = matched[2]
-    next line if level > max_level
+    next line if !level.between?(min_level, max_level)
 
     levels[level - 1] += 1
     (level..max_level).each do |l|
@@ -39,3 +43,4 @@ Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
 
   article.content = converted_lines.join("\n")
 end
+

--- a/lib/jekyll/_plugins/numbered_headings.rb
+++ b/lib/jekyll/_plugins/numbered_headings.rb
@@ -5,7 +5,7 @@ MAX_LEVEL = 6
 
 Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
   # If "numbered-headings: true" in front matter, number regular headings too.
-  global_page_numbered_headings = article.data.fetch("numbered_headings", false)
+  global_page_numbered_headings = article.data.fetch("numbered-headings", false)
   if global_page_numbered_headings
     heading_regex = Regexp.union(HEADING_REGEX, NUMBERED_HEADING_REGEX)
     min_level = article.data.fetch("numbered-headings-min-level", MIN_LEVEL)

--- a/lib/jekyll/_plugins/numbered_headings.rb
+++ b/lib/jekyll/_plugins/numbered_headings.rb
@@ -3,7 +3,7 @@ Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
   levels = Array.new(max_level, 0)
   in_code_block = false
 
-  return unless article.data['numbered-headings'] == true
+  next unless article.data['numbered-headings'] == true
 
   converted_lines = article.content.split("\n").map do |line|
     in_code_block = !in_code_block if line.match(/^```/)

--- a/lib/jekyll/_plugins/numbered_headings.rb
+++ b/lib/jekyll/_plugins/numbered_headings.rb
@@ -12,6 +12,8 @@ Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
     max_level = article.data.fetch("numbered-headings-min-level", MAX_LEVEL)
   else
     heading_regex = NUMBERED_HEADING_REGEX
+    min_level = 1
+    max_level = 6
   end
 
   levels = Array.new(max_level, 0)

--- a/lib/jekyll/_plugins/numbered_headings.rb
+++ b/lib/jekyll/_plugins/numbered_headings.rb
@@ -1,15 +1,23 @@
+NUMBERED_HEADING_REGEX = /^(#+)1\. (.+)/
+HEADING_REGEX = /^(#+) (.+)/
+
 Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |article|
   max_level = 6
   levels = Array.new(max_level, 0)
   in_code_block = false
 
-  next unless article.data['numbered-headings'] == true
+  # If "numbered-headings: true" in front matter, number regular headings too.
+  if article.data["numbered-headings"] == true
+    heading_regex = Regexp.union(HEADING_REGEX, NUMBERED_HEADING_REGEX)
+  else
+    heading_regex = NUMBERED_HEADING_REGEX
+  end
 
   converted_lines = article.content.split("\n").map do |line|
     in_code_block = !in_code_block if line.match(/^```/)
     next line if in_code_block
 
-    matched = line.match(/^(#+) (.+)/)
+    matched = line.match(heading_regex)
     next line unless matched
 
     heading = matched[1]


### PR DESCRIPTION
This PR adds the ability to set

```yaml
numbered-headings: true
```

in the front matter of any page and then all headings in that page will be numbered. The old functionality still works.

Also, if `numbered-headings: true` is set in the front matter, `numbered-headings-min-level` and `numbered-headings-max-level` can also be set to control the heading levels to include in numbering. Default is 2-6.